### PR TITLE
Fix samsung keyboard android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
+## 1.2.0
+
+- Add the `isUsingSamsungKeyboard` function to detect if the user is using a samsung keyboard
+- Add the `patchForSamsungKeyboards` argument to the `patchNumberSeperators` function, to chan 
+
 ## 1.1.1
-- improve error reporting to the developer
+- Improve error reporting to the developer
 
 ## 1.1.0
 - Add the `patchNumberSeperators` function to change decimal and group seperators on all locales.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This will add a line like this to your package's pubspec.yaml (and run an implic
 
 ```
 dependencies:
-  locale_plus: ^1.1.0
+  locale_plus: ^1.2.0
 ```
 
 # Usage
@@ -51,6 +51,11 @@ Future<void> main() async {
   runApp(const MyApp());
 }
 ```
+## Get if the user is using a samsung keyboard
+```Dart
+final decimalSeparator = await LocalePlus().isUsingSamsungKeyboard();
+```
+
 ## Get Decimal & Grouping Separator
 
 ```Dart

--- a/android/src/main/java/com/example/locale_plus/LocalePlusPlugin.java
+++ b/android/src/main/java/com/example/locale_plus/LocalePlusPlugin.java
@@ -1,7 +1,9 @@
 package com.example.locale_plus;
 
 import android.content.Context;
+import android.provider.Settings;
 import android.text.format.DateFormat;
+import android.view.inputmethod.InputMethodManager;
 
 import androidx.annotation.NonNull;
 
@@ -27,7 +29,14 @@ public class LocalePlusPlugin implements FlutterPlugin, MethodCallHandler {
     channel = new MethodChannel(flutterPluginBinding.getBinaryMessenger(), "locale_plus");
     channel.setMethodCallHandler(this);
   }
-
+  private boolean usingKeyboard(@NonNull String keyboardId)
+  {
+    final InputMethodManager richImm =
+            (InputMethodManager)mContext.getSystemService(Context.INPUT_METHOD_SERVICE);
+    String defaultKeyboard = Settings.Secure.getString(mContext.getContentResolver(),
+            Settings.Secure.DEFAULT_INPUT_METHOD);
+    return defaultKeyboard.contains(keyboardId);
+  }
   @Override
   public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {
     Locale currentLocale =  mContext.getResources().getConfiguration().locale;
@@ -69,6 +78,9 @@ public class LocalePlusPlugin implements FlutterPlugin, MethodCallHandler {
     else if (call.method.equals(MethodNames.getTimeZoneIdentifier.getText())){
       String timeZoneIdentifier = TimeZone.getDefault().getID();
       result.success(timeZoneIdentifier);
+    }
+    else if (call.method.equals(MethodNames.isUsingSamsungKeyboard.getText())){
+      result.success(usingKeyboard("Samsung"));
     }
     else {
       result.notImplemented();

--- a/android/src/main/java/com/example/locale_plus/MethodNames.java
+++ b/android/src/main/java/com/example/locale_plus/MethodNames.java
@@ -10,7 +10,8 @@ public enum MethodNames {
     is24HourTime("is24HourTime"),
     getAmSymbol("getAmSymbol"),
     getPmSymbol("getPmSymbol"),
-    getTimeZoneIdentifier("getTimeZoneIdentifier");
+    getTimeZoneIdentifier("getTimeZoneIdentifier"),
+    isUsingSamsungKeyboard("isUsingSamsungKeyboard");
 
     private final String text;
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -19,6 +19,7 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   String? decimalSeparator;
   String? groupingSeparator;
+  bool? isUsingSamsungKeyboard;
   int? secondsFromGMT;
   String? regionCode;
   String? languageCode;
@@ -37,6 +38,7 @@ class _MyAppState extends State<MyApp> {
   Future<void> initPlatformState() async {
     decimalSeparator = await LocalePlus().getDecimalSeparator();
     groupingSeparator = await LocalePlus().getGroupingSeparator();
+    isUsingSamsungKeyboard = await LocalePlus().isUsingSamsungKeyboard();
     secondsFromGMT = await LocalePlus().getSecondsFromGMT();
     regionCode = await LocalePlus().getRegionCode();
     languageCode = await LocalePlus().getLanguageCode();
@@ -65,6 +67,10 @@ class _MyAppState extends State<MyApp> {
               ),
               Text(
                 'Grouping Separator: $groupingSeparator',
+                textAlign: TextAlign.center,
+              ),
+              Text(
+                'is using samsung keybaord: $isUsingSamsungKeyboard',
                 textAlign: TextAlign.center,
               ),
               Text(

--- a/lib/locale_plus.dart
+++ b/lib/locale_plus.dart
@@ -1,5 +1,14 @@
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+
 import 'locale_plus_platform_interface.dart';
 export 'patch_all_locales.dart' show PatchAllLocales;
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:universal_io/io.dart';
+
+@protected
+final os = kIsWeb ? 'the browser' : Platform.operatingSystem;
 
 /// Locale plus is an easy way to get native devices Locale data.
 class LocalePlus {

--- a/lib/locale_plus.dart
+++ b/lib/locale_plus.dart
@@ -17,6 +17,10 @@ class LocalePlus {
     return LocalePlusPlatform.instance.getDecimalSeparator();
   }
 
+  ///Returns true if the user is using a samsung keyboard. false otherwise.
+  Future<bool?> isUsingSamsungKeyboard() =>
+      LocalePlusPlatform.instance.isUsingSamsungKeyboard();
+
   /// Returns the grouping separator for the current locale of device.
   Future<String?> getGroupingSeparator() {
     return LocalePlusPlatform.instance.getGroupingSeparator();

--- a/lib/locale_plus_method_channel.dart
+++ b/lib/locale_plus_method_channel.dart
@@ -13,6 +13,13 @@ class MethodChannelLocalePlus extends LocalePlusPlatform {
   }
 
   @override
+  Future<bool?> isUsingSamsungKeyboard() async {
+    final decimalSeparator =
+        await methodChannel.invokeMethod<bool>('isUsingSamsungKeyboard');
+    return decimalSeparator;
+  }
+
+  @override
   Future<String?> getGroupingSeparator() async {
     final groupingSeparator =
         await methodChannel.invokeMethod<String>('getGroupingSeparator');

--- a/lib/locale_plus_platform_interface.dart
+++ b/lib/locale_plus_platform_interface.dart
@@ -17,6 +17,9 @@ abstract class LocalePlusPlatform extends PlatformInterface {
     _instance = instance;
   }
 
+  Future<bool?> isUsingSamsungKeyboard() => throw UnimplementedError(
+      'getDecimalSeparator() has not been implemented on $os.');
+
   Future<String?> getDecimalSeparator() => throw UnimplementedError(
       'getDecimalSeparator() has not been implemented on $os.');
 

--- a/lib/locale_plus_platform_interface.dart
+++ b/lib/locale_plus_platform_interface.dart
@@ -1,3 +1,4 @@
+import 'package:locale_plus/locale_plus.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import 'locale_plus_method_channel.dart';
@@ -16,45 +17,35 @@ abstract class LocalePlusPlatform extends PlatformInterface {
     _instance = instance;
   }
 
-  Future<String?> getDecimalSeparator() {
-    throw UnimplementedError('getDecimalSeparator() has not been implemented.');
-  }
+  Future<String?> getDecimalSeparator() => throw UnimplementedError(
+      'getDecimalSeparator() has not been implemented on $os.');
 
-  Future<String?> getGroupingSeparator() {
-    throw UnimplementedError(
-        'getGroupingSeparator() has not been implemented.');
-  }
+  Future<String?> getGroupingSeparator() => throw UnimplementedError(
+      'getGroupingSeparator() has not been implemented on $os.');
 
-  Future<int?> getSecondsFromGMT() {
-    throw UnimplementedError('getSecondsFromGMT() has not been implemented.');
-  }
+  Future<int?> getSecondsFromGMT() => throw UnimplementedError(
+      'getSecondsFromGMT() has not been implemented on $os.');
 
-  Future<String?> getRegionCode() {
-    throw UnimplementedError('getRegionCode() has not been implemented.');
-  }
+  Future<String?> getRegionCode() => throw UnimplementedError(
+      'getRegionCode() has not been implemented on $os.');
 
   Future<String?> getLanguageCode() {
-    throw UnimplementedError('getLanguageCode() has not been implemented.');
-  }
-
-  Future<bool?> usesMetricSystem() {
-    throw UnimplementedError('usesMetricSystem() has not been implemented.');
-  }
-
-  Future<bool?> is24HourTime() {
-    throw UnimplementedError('is24HourTime() has not been implemented.');
-  }
-
-  Future<String?> getAmSymbol() {
-    throw UnimplementedError('getAmSymbol() has not been implemented.');
-  }
-
-  Future<String?> getPmSymbol() {
-    throw UnimplementedError('getPmSymbol() has not been implemented.');
-  }
-
-  Future<String?> getTimeZoneIdentifier() {
     throw UnimplementedError(
-        'getTimeZoneIdentifier() has not been implemented.');
+        'getLanguageCode() has not been implemented on $os.');
   }
+
+  Future<bool?> usesMetricSystem() => throw UnimplementedError(
+      'usesMetricSystem() has not been implemented on $os.');
+
+  Future<bool?> is24HourTime() => throw UnimplementedError(
+      'is24HourTime() has not been implemented on $os.');
+
+  Future<String?> getAmSymbol() => throw UnimplementedError(
+      'getAmSymbol() has not been implemented on $os.');
+
+  Future<String?> getPmSymbol() => throw UnimplementedError(
+      'getPmSymbol() has not been implemented on $os.');
+
+  Future<String?> getTimeZoneIdentifier() => throw UnimplementedError(
+      'getTimeZoneIdentifier() has not been implemented on $os.');
 }

--- a/lib/patch_all_locales.dart
+++ b/lib/patch_all_locales.dart
@@ -71,10 +71,8 @@ please create an issue on https://github.com/gokberkbar/locale_plus''');
             groupingSeparator: groupingSeperator);
       }
     } on MissingPluginException {
-      final os = kIsWeb ? 'the browser' : Platform.operatingSystem;
-      debugPrint('''
-locale_plus: plugin is not implemented on $os.
-The locales are not patched.''');
+      debugPrint(
+          '''locale_plus: plugin is not implemented on $os. The locales are not patched.''');
     }
   }
 }

--- a/lib/patch_all_locales.dart
+++ b/lib/patch_all_locales.dart
@@ -3,8 +3,6 @@ import 'package:flutter/widgets.dart';
 import 'package:intl/number_symbols.dart';
 import 'package:intl/number_symbols_data.dart';
 import 'package:locale_plus/locale_plus.dart';
-import 'package:universal_io/io.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
 
 extension on NumberSymbols {
   NumberSymbols overrideDecimalSeperator(

--- a/lib/patch_all_locales.dart
+++ b/lib/patch_all_locales.dart
@@ -73,7 +73,7 @@ please create an issue on https://github.com/gokberkbar/locale_plus''');
     } on MissingPluginException {
       final os = kIsWeb ? 'the browser' : Platform.operatingSystem;
       debugPrint('''
-The locale_plus plugin is not implemented on $os.
+locale_plus: plugin is not implemented on $os.
 The locales are not patched.''');
     }
   }

--- a/lib/patch_all_locales.dart
+++ b/lib/patch_all_locales.dart
@@ -30,14 +30,37 @@ extension on NumberSymbols {
 ///The [PatchAllLocales] exposes async functions
 ///to patch the locales in [numberFormatSymbols].
 class PatchAllLocales {
+  ///Finds the correct decimal seperator
+  static Future<String?> _getDecimalSeperator(LocalePlus localePlus,
+      {required bool patchDecimal,
+      required bool patchForSamsungKeyboards}) async {
+    if (!patchDecimal) {
+      return null;
+    }
+    if (patchForSamsungKeyboards) {
+      final isUsingSamsungKeyboard = await localePlus.isUsingSamsungKeyboard();
+      if (isUsingSamsungKeyboard != null && isUsingSamsungKeyboard) {
+        return '.';
+      }
+    }
+    return await localePlus.getDecimalSeparator();
+  }
+
   ///[patchNumberSeperators] patches all locales with the
   ///decimal seperators to the decimal separator of the user.
   ///Patching the [DECIMAL_SEP] can be disabled,
   ///by changing the [patchDecimal] to false.
   ///Patching the [GROUP_SEP] can be disabled,
   ///by changing the [patchGroup] to false.
+  ///The locales can also be patched for users with a samsung keyboard.
+  /// This is done by changing the [patchForSamsungKeyboards] to true.
+  /// The samsung keyboard always uses a '.' as input.
+  /// see https://github.com/flutter/flutter/issues/61175
+
   static Future<void> patchNumberSeperators(
-      {bool patchDecimal = true, bool patchGroup = true}) async {
+      {bool patchDecimal = true,
+      bool patchGroup = true,
+      bool patchForSamsungKeyboards = false}) async {
     final localePlus = LocalePlus();
     if (!patchDecimal && !patchGroup) {
       return debugPrint('''
@@ -46,8 +69,10 @@ The locales are not patched.
 ''');
     }
     try {
-      final String? userDecimalSeperator =
-          patchDecimal ? (await localePlus.getDecimalSeparator()) : null;
+      final userDecimalSeperator = await _getDecimalSeperator(localePlus,
+          patchDecimal: patchDecimal,
+          patchForSamsungKeyboards: patchForSamsungKeyboards);
+
       final String? groupingSeperator =
           patchGroup ? (await localePlus.getGroupingSeparator()) : null;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: locale_plus
 description: LocalePlus allows easy access to native device locale data in Flutter apps. Includes language, country code, time zone, and number formatting preferences.
-version: 1.1.1
+version: 1.2.0
 repository: https://github.com/gokberkbar/locale_plus
 
 environment:


### PR DESCRIPTION
Merge #5 first!
This PR adds the `isUsingSamsungKeyboard` method to detect if the user is using a samsung keyboard.
The  `patchNumberSeperators` has also been updated

## Pre-launch Checklist

- [x] I updated `pubspec.yaml` with an appropriate new version.
- [x] I updated `CHANGELOG.md` with new version number and description.
- [x] I updated `README.md`.
- [x] I updated example project with new feature.
- [x] Check if the branch name is correct.
- [x] Code is warning free.
