### PR TITLE
First day of week pr

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ final usesMetricSystem = await LocalePlus().usesMetricSystem();
 final timeZoneIdentifier = await LocalePlus().getTimeZoneIdentifier();
 ```
 
+## Get First Day Of Week
+
+```Dart
+final firstDayOfWeek = await LocalePlus().getFirstDayOfWeek();
+```
+
 # Author
 
 [Gökberk Bardakçı](https://www.github.com/gokberkbar), [Uygar İşiçelik](https://www.github.com/uygar)

--- a/android/src/main/java/com/example/locale_plus/LocalePlusPlugin.java
+++ b/android/src/main/java/com/example/locale_plus/LocalePlusPlugin.java
@@ -1,6 +1,7 @@
 package com.example.locale_plus;
 
 import android.content.Context;
+import android.os.Build;
 import android.provider.Settings;
 import android.text.format.DateFormat;
 import android.view.inputmethod.InputMethodManager;
@@ -9,6 +10,8 @@ import androidx.annotation.NonNull;
 
 import java.text.DateFormatSymbols;
 import java.text.DecimalFormatSymbols;
+import java.time.temporal.WeekFields;
+import java.util.Calendar;
 import java.util.Locale;
 import java.util.TimeZone;
 
@@ -82,6 +85,9 @@ public class LocalePlusPlugin implements FlutterPlugin, MethodCallHandler {
     else if (call.method.equals(MethodNames.isUsingSamsungKeyboard.getText())){
       result.success(usingKeyboard("samsung"));
     }
+    else if (call.method.equals(MethodNames.getFirstDayOfWeek.getText())) {
+      result.success(getFirstDayOfWeek(currentLocale));
+    }
     else {
       result.notImplemented();
     }
@@ -96,6 +102,21 @@ public class LocalePlusPlugin implements FlutterPlugin, MethodCallHandler {
         return false;
       default:
         return true;
+    }
+  }
+
+  private int getFirstDayOfWeek(Locale locale) {
+    if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      WeekFields weekFields = WeekFields.of(locale);
+      return weekFields.getFirstDayOfWeek().getValue();
+    } else {
+      Calendar cal = Calendar.getInstance(locale);
+      int firstDayOfWeek = cal.getFirstDayOfWeek();
+      if (firstDayOfWeek == 1) {
+        return 7;
+      } else {
+        return firstDayOfWeek - 1;
+      }
     }
   }
 

--- a/android/src/main/java/com/example/locale_plus/MethodNames.java
+++ b/android/src/main/java/com/example/locale_plus/MethodNames.java
@@ -11,7 +11,8 @@ public enum MethodNames {
     getAmSymbol("getAmSymbol"),
     getPmSymbol("getPmSymbol"),
     getTimeZoneIdentifier("getTimeZoneIdentifier"),
-    isUsingSamsungKeyboard("isUsingSamsungKeyboard");
+    isUsingSamsungKeyboard("isUsingSamsungKeyboard"),
+    getFirstDayOfWeek("getFirstDayOfWeek");
 
     private final String text;
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -30,6 +30,7 @@ class _MyAppState extends State<MyApp> {
   String? amSymbol;
   String? pmSymbol;
   String? timeZoneIdentifier;
+  int? firstDayOfWeek;
 
   @override
   void initState() {
@@ -49,6 +50,7 @@ class _MyAppState extends State<MyApp> {
     amSymbol = await LocalePlus().getAmSymbol();
     pmSymbol = await LocalePlus().getPmSymbol();
     timeZoneIdentifier = await LocalePlus().getTimeZoneIdentifier();
+    firstDayOfWeek = await LocalePlus().getFirstDayOfWeek();
     setState(() {});
   }
 
@@ -105,6 +107,10 @@ class _MyAppState extends State<MyApp> {
               ),
               Text(
                 'Time Zone Identifier: $timeZoneIdentifier',
+                textAlign: TextAlign.center,
+              ),
+              Text(
+                'First day of week: $firstDayOfWeek',
                 textAlign: TextAlign.center,
               ),
             ],

--- a/ios/Classes/MethodNames.swift
+++ b/ios/Classes/MethodNames.swift
@@ -9,4 +9,5 @@ enum MethodNames: String {
     case getAmSymbol = "getAmSymbol"
     case getPmSymbol = "getPmSymbol"
     case getTimeZoneIdentifier = "getTimeZoneIdentifier"
+    case getFirstDayOfWeek = "getFirstDayOfWeek"
 }

--- a/ios/Classes/SwiftLocalePlusPlugin.swift
+++ b/ios/Classes/SwiftLocalePlusPlugin.swift
@@ -30,6 +30,8 @@ public class SwiftLocalePlusPlugin: NSObject, FlutterPlugin {
           result(getPrefferedLanguageLocale().calendar.pmSymbol)
       case MethodNames.getTimeZoneIdentifier.rawValue:
           result(TimeZone.autoupdatingCurrent.identifier)
+      case MethodNames.getFirstDayOfWeek.rawValue:
+          result(getFirstDayOfWeek())
       default:
           return
       }
@@ -49,6 +51,15 @@ public class SwiftLocalePlusPlugin: NSObject, FlutterPlugin {
             return Locale.autoupdatingCurrent.measurementSystem == Locale.MeasurementSystem.metric
         } else {
             return Locale.autoupdatingCurrent.usesMetricSystem
+        }
+    }
+
+    private func getFirstDayOfWeek() -> Int {
+        let firstDay = Calendar.current.firstWeekday;
+        if (firstDay == 1) {
+            return 7;
+        } else {
+            return firstDay - 1;
         }
     }
     

--- a/lib/locale_plus.dart
+++ b/lib/locale_plus.dart
@@ -65,4 +65,11 @@ class LocalePlus {
   Future<String?> getTimeZoneIdentifier() {
     return LocalePlusPlatform.instance.getTimeZoneIdentifier();
   }
+
+  /// Returns the first day of week for the current locale of device.
+  /// The values are numbered following the ISO-8601 standard,
+  /// from 1 (Monday) to 7 (Sunday).
+  Future<int?> getFirstDayOfWeek() {
+    return LocalePlusPlatform.instance.getFirstDayOfWeek();
+  }
 }

--- a/lib/locale_plus_method_channel.dart
+++ b/lib/locale_plus_method_channel.dart
@@ -81,4 +81,11 @@ class MethodChannelLocalePlus extends LocalePlusPlatform {
         await methodChannel.invokeMethod<String>('getTimeZoneIdentifier');
     return timeZoneIdentifier;
   }
+
+  @override
+  Future<int?> getFirstDayOfWeek() async {
+    final firstDayOfWeek =
+        await methodChannel.invokeMethod<int>('getFirstDayOfWeek');
+    return firstDayOfWeek;
+  }
 }

--- a/lib/locale_plus_platform_interface.dart
+++ b/lib/locale_plus_platform_interface.dart
@@ -51,4 +51,7 @@ abstract class LocalePlusPlatform extends PlatformInterface {
 
   Future<String?> getTimeZoneIdentifier() => throw UnimplementedError(
       'getTimeZoneIdentifier() has not been implemented on $os.');
+
+  Future<int?> getFirstDayOfWeek() => throw UnimplementedError(
+      'getFirstDayOfWeek() has not been implemented on $os.');
 }


### PR DESCRIPTION
Added getting the first day of week. The values are numbered following the ISO-8601 standard, from 1 (Monday) to 7 (Sunday). 

On iOS respects "First Day of Week" setting in Language & Region settings. So for default us_US locale the method returns 7 (which means Sunday). But if you select for example Wednesday as "First Day of Week" in settings the method will return 3. 
