### PR TITLE
fix: enhanced Samsung keyboard check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.4.1
+- Enhanced the `isUsingSamsungKeyboard` native check to improve the Samsung keyboards recognition.
+
 ## 1.4.0
 - Add the `getFirstDayOfWeek` function to getting the first day of week from a current locale on Android or from "Language & Region" settings on iOS.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This will add a line like this to your package's pubspec.yaml (and run an implic
 
 ```
 dependencies:
-  locale_plus: ^1.4.0
+  locale_plus: ^1.4.1
 ```
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ final firstDayOfWeek = await LocalePlus().getFirstDayOfWeek();
 
 # Contributors
 
-[Bent Engbers](https://github.com/BentEngbers), [Renat Shakhmatov](https://github.com/shushper)
+[Bent Engbers](https://github.com/BentEngbers), [Renat Shakhmatov](https://github.com/shushper), [Giovanni Lattanzio](https://github.com/giovannilattanziocrispy)
 
 # License
 

--- a/android/src/main/java/com/example/locale_plus/LocalePlusPlugin.java
+++ b/android/src/main/java/com/example/locale_plus/LocalePlusPlugin.java
@@ -38,7 +38,14 @@ public class LocalePlusPlugin implements FlutterPlugin, MethodCallHandler {
             (InputMethodManager)mContext.getSystemService(Context.INPUT_METHOD_SERVICE);
     String defaultKeyboard = Settings.Secure.getString(mContext.getContentResolver(),
             Settings.Secure.DEFAULT_INPUT_METHOD);
-    return defaultKeyboard.contains(keyboardId);
+    if(defaultKeyboard == null)
+    {
+      return false;
+    }
+    else {
+      defaultKeyboard = defaultKeyboard.toLowerCase();
+    }
+    return defaultKeyboard.contains(keyboardId.toLowerCase());
   }
   @Override
   public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -105,7 +105,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.1"
+    version: "1.4.1"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: locale_plus
 description: LocalePlus allows easy access to native device locale data in Flutter apps. Includes language, country code, time zone, and number formatting preferences.
-version: 1.4.0
+version: 1.4.1
 repository: https://github.com/gokberkbar/locale_plus
 
 environment:


### PR DESCRIPTION
*Replace this paragraph with a description of PR*

## Pre-launch Checklist

- [x] I updated `pubspec.yaml` with an appropriate new version.
- [x] I updated `CHANGELOG.md` with new version number and description.
- [x] I updated `README.md`.
- [x] I updated example project with new feature.
- [x] Check if the branch name is correct.
- [x] Code is warning free.

I updated the `isUsingSamsungKeyboard` check on the Android native code, because I saw that sometimes the result from `String defaultKeyboard = Settings.Secure.getString(mContext.getContentResolver(), Settings.Secure.DEFAULT_INPUT_METHOD);` contains the word "Samsung" with a capital letter.

Example from a Samsung Galaxy S6: `com.sec.android.inputmethod/.SamsungKeypad`.

I compared the two strings (request and input keyboard signature) transforming them  to lower case.